### PR TITLE
Fixes voces/jass-to-ast#5

### DIFF
--- a/src/grammar/jass.ne
+++ b/src/grammar/jass.ne
@@ -325,12 +325,12 @@ left_right_prod_op         -> right_rod_op _ ("*"|"/") _ left_expr              
 unary_op                   -> _unary_op                                                                     {%e().flat().reorder(0, 2).kind('unary_op')%}
 _unary_op                  -> ("+"|"-") _ _expr
                             | "not" __ _expr
-                            | "not" left_expr
+                            | "not" _ left_expr
 
 left_unary_op              -> _left_unary_op                                                                {%e().flat().reorder(0, 2).kind('unary_op')%}
 _left_unary_op             -> ("+"|"-") _ left_expr
                             | "not" __ left_expr
-                            | "not" left_right_expr
+                            | "not" _ left_right_expr
 
 func_call                  -> name "(" _ (args _):? ")"                                                     {%e().flat().reorder(0, 3).kind('call')%}
 


### PR DESCRIPTION
I noticed that jass-to-ts has issues with functions like the following:

```lua
	function f takes nothing returns boolean
		if(not(udg_a==udg_b))then
			return false
		endif
	endfunction
```

The underlying issue seems to be the slight error in the grammar, that this PR corrects.